### PR TITLE
Fix: E702: Tags must contain lowercase letters and digits only, invalid: 'AWS'

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,9 +26,13 @@ galaxy_info:
         - raring
         - saucy
   galaxy_tags:
-    - aws
     - amazon
-    - cloudformation
-    - cloud
+    - aws
     - cfn
+    - cloud
+    - cloudformation
+    - deployment
+    - diff
+    - jinja2
+    - template
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   platforms:
     - name: Amazon
       versions:
-       - all
+        - all
     - name: EL
       versions:
         - 5
@@ -26,7 +26,6 @@ galaxy_info:
         - raring
         - saucy
   galaxy_tags:
-    - AWS
     - aws
     - amazon
     - cloudformation


### PR DESCRIPTION
# Metadata fix



* **Fixes:** `E702: Tags must contain lowercase letters and digits only, invalid: 'AWS'`
* **Improves:** General tagging in metadata