### PR TITLE
Use termination_protection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ services:
 ###
 env:
   matrix:
-    - ansible=2.4
     - ansible=2.5
     - ansible=2.6
     - ansible=2.7

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ endif
 .PHONY: help lint galaxy test _lint_yaml _lint_syntax _lint_ansible
 
 CURRENT_DIR     = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-ANSIBLE_VERSION = 2.4
+ANSIBLE_VERSION = 2.5
 
 help:
 	@echo "lint       Static source code analysis"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifneq (,)
 .error This Makefile requires GNU Make.
 endif
 
-.PHONY: help lint galaxy test _lint_yaml _lint_syntax _lint_ansible
+.PHONY: help lint galaxy test _lint-ansible-syntax _lint-ansible-lint _lint-yamllint _lint-pycodestyle
 
 CURRENT_DIR     = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ANSIBLE_VERSION = 2.5
@@ -16,9 +16,10 @@ lint:
 	@echo "================================================================================"
 	@echo "= LINTING"
 	@echo "================================================================================"
-	@$(MAKE) --no-print-directory _lint_yaml
-	@$(MAKE) --no-print-directory _lint_syntax
-	@$(MAKE) --no-print-directory _lint_ansible
+	@$(MAKE) --no-print-directory _lint-ansible-syntax
+	@$(MAKE) --no-print-directory _lint-ansible-lint
+	@$(MAKE) --no-print-directory _lint-yamllint
+	@$(MAKE) --no-print-directory _lint-pycodestyle
 
 galaxy:
 	@echo "================================================================================"
@@ -48,7 +49,7 @@ test: ansible.cfg
 ansible.cfg:
 	printf '[defaults]\nroles_path=../' > ansible.cfg
 
-_lint_yaml:
+_lint-yamllint:
 	@echo "------------------------------------------------------------"
 	@echo "- yamllint"
 	@echo "------------------------------------------------------------"
@@ -56,7 +57,7 @@ _lint_yaml:
 		-v $(CURRENT_DIR):/data/ \
 		cytopia/yamllint .
 
-_lint_syntax: ansible.cfg
+_lint-ansible-syntax: ansible.cfg
 	@echo "------------------------------------------------------------"
 	@echo "- ansible-playbook --syntax-check"
 	@echo "------------------------------------------------------------"
@@ -66,12 +67,19 @@ _lint_syntax: ansible.cfg
 		cytopia/ansible:$(ANSIBLE_VERSION) \
 		ansible-playbook tests/test.yml -i tests/inventory -vv --syntax-check
 
-_lint_ansible: ansible.cfg
+_lint-ansible-lint: ansible.cfg
 	@echo "------------------------------------------------------------"
 	@echo "- ansible-lint"
 	@echo "------------------------------------------------------------"
 	docker run --rm \
 		-w /data/ansible-role-cloudformation \
 		-v $(CURRENT_DIR):/data/ansible-role-cloudformation \
-		cytopia/ansible-lint \
-		ansible-lint -vv tests/test.yml
+		cytopia/ansible-lint -v tests/test.yml
+
+_lint-pycodestyle:
+	@echo "------------------------------------------------------------"
+	@echo "- pycodestyle"
+	@echo "------------------------------------------------------------"
+	docker run --rm \
+		-v $(CURRENT_DIR):/data/ \
+		cytopia/pycodestyle -v .

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ This section contains a more detailed describtion about available dict or array 
 | `security_token` | string | optional | AWS security token to use |
 | `profile` | string | optional | AWS boto profile to use |
 | `notification_arns` | string | optional | Publish stack notifications to these ARN's |
+| `termination_protection` | bool | optional | Enable or disable termination protection on the stack. Only works with botocore >= 1.7.18 |
 | `region` | string | optional | AWS region to deploy stack to |
 
 #### `cloudformation_stacks`
@@ -95,6 +96,7 @@ This section contains a more detailed describtion about available dict or array 
 | `security_token` | string | optional | AWS security token to use (overwrites default) |
 | `profile` | string | optional | AWS boto profile to use (overwrites default) |
 | `notification_arns` | string | optional | Publish stack notifications to these ARN's (overwrites default) |
+| `termination_protection` | bool | optional | Enable or disable termination protection on the stack. Only works with botocore >= 1.7.18 |
 | `region` | string | optional | AWS region to deploy stack to (overwrites default) |
 | `template_parameters` | dict | optional | Required cloudformation stack parameters |
 | `tags` | dict | optional | Tags associated with the cloudformation stack |
@@ -125,6 +127,7 @@ cloudformation_stacks:
   - stack_name: stack-lambda
     template: files/cloudformation/lambda.yml.j2
     profile: production
+    termination_protection: True
     template_parameters:
       lambdaFunctionName: lambda
       handler: lambda.run_handler
@@ -170,6 +173,7 @@ cloudformation_stacks:
   # Second stack
   - stack_name: stack-lambda
     profile: testing
+    termination_protection: True
     region: eu-central-1
     template: files/cloudformation/lambda.yml.j2
     template_parameters:
@@ -457,7 +461,7 @@ This role does not depend on any other roles.
 
 ## Requirements
 
-Use at least **Ansible 2.4** in order to also have `--check` mode for cloudformation.
+Use at least **Ansible 2.5** in order to also have `--check` mode for cloudformation.
 
 The python module `cfn_flip` is required, when using line-by-line diff of local and remote Cloudformation templates (`cloudformation_run_diff=True`). This can easily be installed locally:
 ```bash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ cloudformation_defaults: {}
 #  security_token:
 #  profile:
 #  notification_arns:
+#  termination_protection
 #  region:
 
 
@@ -79,6 +80,7 @@ cloudformation_stacks: []
 #    security_token:
 #    profile:
 #    notification_arns:
+#    termination_protection
 #    region:
 #    template_parameters:
 #      param1: val1

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   company: cytopia
   license: MIT
   description: Ansible role to render an arbitrary number of Jinja2 templates into cloudformation files and create any number of stacks.
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
   platforms:
     - name: Amazon
       versions:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[pycodestyle]
+count = True
+ignore =  E402
+max-line-length = 160
+statistics = True

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -77,6 +77,7 @@
     profile: "{{ cloudformation.profile | default(cloudformation_defaults.profile | default(omit)) }}"
     region: "{{ cloudformation.region | default(cloudformation_defaults.region | default(omit)) }}"
     notification_arns: "{{ cloudformation.notification_arns | default(cloudformation_defaults.notification_arns | default(omit)) }}"
+    termination_protection: "{{ cloudformation.termination_protextion | default(cloudformation_defaults.termination_protection | default(omit)) }}"
     template_parameters: "{{ cloudformation.template_parameters | default(omit) }}"
     tags: "{{ cloudformation.tags | default(omit) }}"
   when: not cloudformation_generate_only


### PR DESCRIPTION
# Use termination_protection

This PR enables `termination_protection` to be used as global defaults and/or on a per stack base.

## Implications
`termination_protection` is available since Ansible 2.5 and this role needs to bump its minimum requirements from Ansible 2.4 to Ansible 2.5 (see here: https://docs.ansible.com/ansible/latest/modules/cloudformation_module.html)

In order to visualize this, the major version will be bumped after merge to `v2.0.0`

* Fixes #21 